### PR TITLE
feat: icon sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ import { AirplayIcon, AtSignIcon, ... } from 'vue-feather-icons'
 
 See all icons and usage here: https://vue-feather-icons.netlify.com
 
+### Sizing
+
+By default, icons will be sized based on the font size of the parent element.
+
+You can set a custom size using the `size` attribute. 
+For multiple based sizing, pass the desired multiple followed by an `x`.
+
+```html
+<activity-icon size="1.5x" class="custom-class"></activity-icon> 
+```
+
+You can also set a `px` size directly by just passing an integer
+
+```html
+<activity-icon size="25" class="custom-class"></activity-icon> 
+```
+
 ## Tree shaking
 
 By using ES imports like `import { AirplayIcon } from 'vue-feather-icons'` with [webpack + minifier](https://webpack.js.org/guides/tree-shaking/#minify-the-output) or Rollup, unused exports in this module will be automatically eliminated.

--- a/build.js
+++ b/build.js
@@ -6,10 +6,29 @@ const fs = require('fs-extra')
 const componentTemplate = (name, svg) => `
 export default {
   name: '${name}',
+  
+  props: {
+    size: {
+      type: String,
+      default: '1x',
+      validator: (s) => (!isNaN(s) || s.length >= 2 && !isNaN(s.slice(0, s.length -1)) && s.slice(-1) === 'x' )
+    }
+  },
 
   functional: true,
 
   render(h, ctx) {
+    const size = ctx.props.size.slice(-1) === 'x' 
+      ? ctx.props.size.slice(0, ctx.props.size.length -1) + 'em'
+      : parseInt(ctx.props.size) + 'px';
+    
+    ctx.data.style = {
+      'height': size,
+      'width': size,
+      'pointer-events': 'none',
+      'vertical-align': 'middle'
+    }
+  
     return ${svg.replace(/<svg([^>]+)>/, '<svg$1 {...ctx.data}>')}
   }
 }

--- a/build.js
+++ b/build.js
@@ -10,7 +10,7 @@ export default {
   props: {
     size: {
       type: String,
-      default: '1x',
+      default: '24',
       validator: (s) => (!isNaN(s) || s.length >= 2 && !isNaN(s.slice(0, s.length -1)) && s.slice(-1) === 'x' )
     }
   },
@@ -22,12 +22,9 @@ export default {
       ? ctx.props.size.slice(0, ctx.props.size.length -1) + 'em'
       : parseInt(ctx.props.size) + 'px';
     
-    ctx.data.style = {
-      'height': size,
-      'width': size,
-      'pointer-events': 'none',
-      'vertical-align': 'middle'
-    }
+    ctx.data.attrs = ctx.attrs || {};
+    ctx.data.attrs.width = size;
+    ctx.data.attrs.height = size;
   
     return ${svg.replace(/<svg([^>]+)>/, '<svg$1 {...ctx.data}>')}
   }

--- a/build.js
+++ b/build.js
@@ -21,10 +21,11 @@ export default {
     const size = ctx.props.size.slice(-1) === 'x' 
       ? ctx.props.size.slice(0, ctx.props.size.length -1) + 'em'
       : parseInt(ctx.props.size) + 'px';
-    
-    ctx.data.attrs = ctx.attrs || {};
-    ctx.data.attrs.width = size;
-    ctx.data.attrs.height = size;
+
+    const attrs = ctx.data.attrs || {}
+    attrs.width = attrs.width || size
+    attrs.height = attrs.height || size
+    ctx.data.attrs = attrs
   
     return ${svg.replace(/<svg([^>]+)>/, '<svg$1 {...ctx.data}>')}
   }

--- a/example/App.vue
+++ b/example/App.vue
@@ -41,7 +41,9 @@
             @click="handleClickSize(size)"
             :key="size"
             :title="sizeExample(size)">
-            <div class="size-label">{{ size }}</div>
+            <div class="size-label">
+              {{ size }}{{ size === '1x' ? ' (default)' : '' }}
+            </div>
             <div class="size-icon">
               <archive-icon :size="size"></archive-icon>
             </div>

--- a/example/App.vue
+++ b/example/App.vue
@@ -27,7 +27,7 @@
           v-for="icon in filteredIcons"
           @click="handleClickIcon(icon)"
           :key="icon">
-          <component :is="icon" size="1.5x" class="icon-svg"></component>
+          <component :is="icon" class="icon-svg"></component>
           <span>{{ icon }}</span>
         </div>
       </div>
@@ -38,7 +38,7 @@
             class="size"
             v-for="size in exampleSizes"
             v-tippy="{interactive: true}"
-            @click="handleClickIcon(icon)"
+            @click="handleClickSize(size)"
             :key="size"
             :title="sizeExample(size)">
             <div class="size-label">{{ size }}</div>

--- a/example/App.vue
+++ b/example/App.vue
@@ -31,6 +31,23 @@
           <span>{{ icon }}</span>
         </div>
       </div>
+      <div class="sizing">
+        <h2>Sizing</h2>
+        <div class="sizes">
+          <div
+            class="size"
+            v-for="size in exampleSizes"
+            v-tippy="{interactive: true}"
+            @click="handleClickIcon(icon)"
+            :key="size"
+            :title="sizeExample(size)">
+            <div class="size-label">{{ size }}</div>
+            <div class="size-icon">
+              <archive-icon :size="size"></archive-icon>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <footer class="footer">
       <div class="container">
@@ -52,7 +69,9 @@ export default {
       icons: Object.keys(icons),
       keyword: '',
       hoverIcon: '',
-      year: new Date().getFullYear()
+      hoverSize: '',
+      year: new Date().getFullYear(),
+      exampleSizes: ['24', '1x', '1.5x', '2x', '3x', '4x']
     }
   },
   computed: {
@@ -68,11 +87,20 @@ export default {
       return example
         .replace(/ICON/g, this.hoverIcon)
         .replace(/kebab-icon/g, kebab(this.hoverIcon))
-    }
+    },
   },
   methods: {
     handleClickIcon(icon) {
       this.hoverIcon = icon
+    },
+    handleClickSize(size) {
+      this.hoverSize = size
+    },
+    sizeExample(size) {
+      return example
+        .replace('1.5x', size)
+        .replace(/ICON/g, 'ArchiveIcon')
+        .replace(/kebab-icon/g, 'archive-icon')
     }
   },
   components: {
@@ -204,6 +232,45 @@ a:hover {
 .footer {
   margin: 40px 0;
   font-size: 1rem
+}
+
+.sizing {
+  text-align: center;
+}
+
+.sizes {
+  width: 80%;
+  margin: auto;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+}
+
+.size {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border-radius: 3px;
+}
+
+.size-label {
+  font-size: 1.5em;
+  font-weight: lighter;
+  color: rgba(0, 0, 0, 0.36);
+  margin-bottom: 0.5em;
+}
+
+.size-icon {
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  margin: 0 auto;
+}
+
+.size:hover {
+  background: #f1f5ff;
 }
 
 @media screen and (max-width: 768px) {

--- a/example/App.vue
+++ b/example/App.vue
@@ -27,7 +27,7 @@
           v-for="icon in filteredIcons"
           @click="handleClickIcon(icon)"
           :key="icon">
-          <component :is="icon" class="icon-svg"></component>
+          <component :is="icon" size="1.5x" class="icon-svg"></component>
           <span>{{ icon }}</span>
         </div>
       </div>
@@ -127,6 +127,10 @@ a:hover {
   overflow: visible;
   word-wrap: normal;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+}
+
+.tippy-popper {
+  max-width: 450px;
 }
 
 .tippy-popper .tippy-tooltip.light-theme[data-animatefill] {

--- a/example/example.md
+++ b/example/example.md
@@ -1,6 +1,6 @@
 ```vue
 <template>
-  <kebab-icon class="custom-class"></kebab-icon>
+  <kebab-icon size="1.5x" class="custom-class"></kebab-icon>
 </template>
 
 <script>


### PR DESCRIPTION
I've had a go at implementing sizing for the icons 😄 

This add two different methods of setting the sizing, either by a multiple or a raw `px` value.

My main concern is that this will be a BC break and require a new major version.
Maybe we could get around this by setting the default size to 24.


I've also added sizing examples to the docs which you can [preview here]
(https://deploy-preview-37--vue-feather-icons.netlify.com/).

![image](https://user-images.githubusercontent.com/50683531/60932802-f65c0a80-a302-11e9-8fa1-df9e4aa7e588.png)

Closes #6


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#6: Icon size?](https://issuehunt.io/repos/99304218/issues/6)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->