### PR TITLE
upgrade to feather-icons 4.24.1 which includes 2 new icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.2.2",
     "bili": "^3.4.2",
     "eslint-config-rem": "^4.0.0",
-    "feather-icons": "^4.10.0",
+    "feather-icons": "^4.24.1",
     "fs-extra": "^8.0.1",
     "lodash.kebabcase": "^4.1.1",
     "marked": "^0.6.0",


### PR DESCRIPTION
Just ran it locally and it adds 2 new icons, Tool (which is what I was looking for) and 1 more. 
So 282 icons total now. 

Didn't update the version in package.json, left it for when you release. 

All the best!
